### PR TITLE
Add repo filtering functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ actuated-samples/kernel-builder-linux-6.0 1              1              0       
 Total usage: 11h24m6s (684 mins)
 ```
 
+You can filter the output by specifying repositories to include with the `-include` and/or `-include-file` option.
+
+```bash
+actions-usage ... -include actuated-samples/ebpf,actuated-samples/dns
+
+---
+Longest build: 18s
+Average build time: 6s
+
+Repo                                      Builds         Success        Failure        Cancelled      Skipped        Total          Average        Longest
+actuated-samples/dns                      9              3              0              6              0              40s            4s             18s
+actuated-samples/ebpf                     5              2              3              0              0              39s            8s             9s
+
+Total usage: 1m19s (1 min)
+```
+
 ## Development
 
 All changes must be proposed with an Issue prior to working on them or sending a PR. Commits must have a sign-off message, i.e. `git commit -s`


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows users to filter the repositories when generating GitHub Actions usage statistics using the CLI tool.

#### Related Issue:
- [x] Resolves: #8

### Before:
Prior to this change, the CLI tool provided general usage statistics for all repositories associated with the target GitHub organization/user. There was no built-in capability to filter the repositories and focus on a select few.

### After:
With this enhancement, users can now specify a set of repositories to filter when generating GitHub Actions usage statistics. This enables them to focus on the specific repositories they care about and obtain more targeted insights.

### Changes Made:
1. Added support for filtering repositories by specifying a comma-separated list of repository names through the `-include` flag or by providing a file containing repository names with the `-include-file` flag.
2. Implemented parsing of repository names from both command-line input and file input.
3. Implemented filtering capability

## Examples

### Before this change

```
./actions-usage -user bxffour -token-file pat.txt
```

Output:

```
Generated by: https://github.com/self-actuated/actions-usage
Report for bxffour - last: 180 days.

Total repos: 22
Total private repos: 0
Total public repos: 22

Total workflow runs: 26
Total workflow jobs: 56

Total users: 1

Success: 34/56
Failure: 4/56
Cancelled: 0/56
Skipped: 18/56

Longest build: 1m19s
Average build time: 21s


Total usage: 19m55s (20 mins)
```

### After this change
```
./actions-usage -user bxffour -token-file pat.txt -by-repo \
	--include bxffour/geoinfo,bxffour/bxffour.github.io
```

Output:
```
Total repos: 2
Total private repos: 0
Total public repos: 2

Total workflow runs: 26
Total workflow jobs: 56

Total users: 1

Success: 34/56
Failure: 4/56
Cancelled: 0/56
Skipped: 18/56

Longest build: 1m19s
Average build time: 21s


Repo                      Builds         Success        Failure        Cancelled      Skipped        Total          Average        Longest
bxffour/geoinfo           44             22             4              0              18             17m33s         24s            1m19s
bxffour/bxffour.github.io 12             12             0              0              0              2m22s          12s            29s

Total usage: 19m55s (20 mins)

```

#### Providing the repo list through a file

```
repos.txt
-------------------------
bxffour/geoinfo
bxffour/namespaces-go
```

```
./actions-usage -user bxffour -token-file pat.txt -by-repo \
	--include-file repos.txt
```

- It is possible to send stdin as a file
```bash
cat repos.txt | ./actions-usage -user bxffour -token-file pat.txt -by-repo  --include-file -
```

- it is also possible to use both the `--include` and the `include-file` options. The filter will include both options
```
./actions-usage -user bxffour -token-file pat.txt -by-repo \
	--include-file repos.txt --include bxffour/bxffour.github.io
```

Output:
The output still includes both `bxffour.github.io` and `bxffour/geoinfo` even though they were provided through different flags.

```
Repo                      Builds         Success        Failure        Cancelled      Skipped        Total          Average        Longest
bxffour/geoinfo           44             22             4              0              18             17m33s         24s            1m19s
bxffour/bxffour.github.io 12             12             0              0              0              2m22s          12s            29s

Total usage: 19m55s (20 mins)

```


## Benefits
- Users can now obtain GitHub Actions usage statistics specifically for the repositories they are interested in, leading to more targeted analysis and insights.
- Provides flexibility and customization by allowing users to filter repositories based on their needs.



