### PR TITLE
Prevent errors in the run for certain repos

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,9 @@ func main() {
 				log.Fatal(err)
 			}
 
-			workflowRuns = append(workflowRuns, runs.WorkflowRuns...)
+			if runs != nil {
+				workflowRuns = append(workflowRuns, runs.WorkflowRuns...)
+			}
 
 			if len(workflowRuns) == 0 {
 				break

--- a/main.go
+++ b/main.go
@@ -170,6 +170,9 @@ func main() {
 			log.Printf("Listing workflow runs for: %s", repo.GetFullName())
 			if orgName != "" {
 				runs, res, err = client.Actions.ListRepositoryWorkflowRuns(ctx, orgName, repo.GetName(), opts)
+				if err != nil {
+					log.Printf("Error getting the workflow runs for: %s", repo.GetFullName())
+				}
 			}
 			if userName != "" {
 				realOwner := userName
@@ -178,6 +181,9 @@ func main() {
 					realOwner = *repo.Owner.Login
 				}
 				runs, res, err = client.Actions.ListRepositoryWorkflowRuns(ctx, realOwner, repo.GetName(), opts)
+				if err != nil {
+					log.Printf("Error getting the workflow runs for: %s", repo.GetFullName())
+				}
 			}
 
 			if _, ok := repoSummary[repo.GetFullName()]; !ok {

--- a/main.go
+++ b/main.go
@@ -172,6 +172,8 @@ func main() {
 				runs, res, err = client.Actions.ListRepositoryWorkflowRuns(ctx, orgName, repo.GetName(), opts)
 				if err != nil {
 					log.Printf("Error getting the workflow runs for: %s", repo.GetFullName())
+					// reset error to prevent stopping the run
+					err = nil
 				}
 			}
 			if userName != "" {
@@ -183,6 +185,8 @@ func main() {
 				runs, res, err = client.Actions.ListRepositoryWorkflowRuns(ctx, realOwner, repo.GetName(), opts)
 				if err != nil {
 					log.Printf("Error getting the workflow runs for: %s", repo.GetFullName())
+					// reset error to prevent stopping the run
+					err = nil
 				}
 			}
 


### PR DESCRIPTION
I've had this happen in a repo with a private vulnerability disclosure that did not have actions available, and thus broke the entire run. This change fixes that.

I expect the same thing will happen if actions is not enabled (for example on a fork).

Fixes #13 